### PR TITLE
Changes for version 1.3

### DIFF
--- a/README
+++ b/README
@@ -2,8 +2,8 @@
 
 
 Product Name:           cigetcert
-Product Version:        1.2
-Date (yyyy/mm/dd):      2016/07/08
+Product Version:        1.3
+Date (yyyy/mm/dd):      2016/07/19
 
 ------------------------------------------------------------------------
 

--- a/cigetcert
+++ b/cigetcert
@@ -70,8 +70,8 @@ def usage(parser, msg):
 def fatal(msg, code=1):
     if (options is None) or not options.quiet:
         if showprogress:
-            print >>sys.stderr
-        print >> sys.stderr, prog + ": " + msg + '\n'
+            print
+        print >> sys.stderr, prog + ": " + msg
     sys.exit(code)
 
 # print exception type name and contents after fatal error message

--- a/cigetcert
+++ b/cigetcert
@@ -26,7 +26,7 @@
 
 
 prog = "cigetcert"
-version = "1.2"
+version = "1.3"
 
 import sys
 import os

--- a/cigetcert
+++ b/cigetcert
@@ -78,6 +78,18 @@ def fatal(msg, code=1):
 def efatal(msg, e, code=1):
     fatal(msg + ': ' + type(e).__name__ + ': ' + str(e), code)
 
+def reusefail(msg, outfile, code=1):
+    global showprogress
+    if options.reuseonly > 0:
+        if showprogress:
+            print " no"
+            showprogress = False
+        if options.reuseonly == 2:
+            fatal(msg + ', and ' + outfile + ' is read-only')
+        fatal(msg + ', and --reuseonly is set')
+    if options.verbose:
+        print msg
+
 # this is from http://python-notes.curiousefficiency.org/en/latest/python_kerberos.html
 def www_auth(handle):
     auth_fields = {}
@@ -378,6 +390,13 @@ def main():
     parser.add_option("-o", "--out", 
                       metavar="path", default="/tmp/x509up_u%uid",
                       help="file path to save certificate and key chain")
+    parser.add_option("", "--reuseonly", 
+                      action="store_const", const=1, default=0,
+                      help="only verify existing proxy can be reused " + \
+                            "[default: true if %out is read-only]")
+    parser.add_option("", "--noreuseonly", 
+                      action="store_const", const=-1, dest="reuseonly",
+                      help="turn off reuseonly; get cert if needed")
     parser.add_option("", "--minhours", 
                       type="float", metavar="num", default=12,
                       help="minimum hours remaining in existing cert chain " + \
@@ -543,110 +562,111 @@ def main():
     username = options.username.replace("%currentuser", pwd.getpwuid(os.geteuid()).pw_name)
     myproxyusername = options.myproxyusername.replace("%username",username)
     outfile = options.out.replace("%uid", str(os.getuid()))
-    try:
-        existing = X509.load_cert(outfile)
-    except Exception, e:
-        if options.debug:
-            print 'Could not load ' + outfile + ': ' + type(e).__name__ + ': ' + str(e), e
-    else:
-        if options.verbose:
-            print "Checking if %s has at least %s hours left" % (outfile, options.minhours)
-        elif showprogress:
-            sys.stdout.write('Checking if ' + outfile + ' can be reused ...')
-            sys.stdout.flush()
-        if str(existing.get_not_after()) == 'Bad time value':
-            # this happens on el5 when the old outfile is empty
-            time_left = 0
+    if os.path.exists(outfile):
+        if options.reuseonly == 0:
+            if not os.access(outfile, os.W_OK):
+                options.reuseonly = 2
+        try:
+            existing = X509.load_cert(outfile)
+        except Exception, e:
+            if options.reuseonly > 0:
+                showprogress = False
+                if options.reuseonly == 2:
+                    efatal('Could not load ' + outfile + ' and it is read-only', e)
+                efatal('Could not load ' + outfile + ' and --reuseonly is set', e)
+            if options.debug:
+                print 'Could not load ' + outfile + ': ' + type(e).__name__ + ': ' + str(e), e
         else:
-            time_left = asn1time_local_secs(existing.get_not_after()) - time.time()
-            if time_left < 0:
+            if options.verbose:
+                print "Checking if %s has at least %s hours left" % (outfile, options.minhours)
+            elif showprogress:
+                sys.stdout.write('Checking if ' + outfile + ' can be reused ...')
+                sys.stdout.flush()
+            if str(existing.get_not_after()) == 'Bad time value':
+                # this happens on el5 when the old outfile is empty
                 time_left = 0
-        existingdn = existing.get_subject()
-        if existingdn.organizationName != options.institution:
-            if options.verbose:
-                print "The organization name does not match institution, skipping"
-            elif showprogress:
-                sys.stdout.write('.')
-                sys.stdout.flush()
-        elif time_left <= (options.minhours * 60 * 60):
-            if options.verbose:
-                print "%.2f hours remaining, not enough" % (time_left / 60.0 / 60.0)
-            elif showprogress:
-                sys.stdout.write('.')
-                sys.stdout.flush()
-        else:
-            if options.verbose:
-                print "%.2f hours remaining, enough to reuse" % (time_left / 60.0 / 60.0)
-            canreuse = False
-            if options.myproxyserver is None:
-                canreuse = True
             else:
-                minhours = options.hours - options.proxyhours - options.minhours
+                time_left = asn1time_local_secs(existing.get_not_after()) - time.time()
+                if time_left < 0:
+                    time_left = 0
+            if time_left <= (options.minhours * 60 * 60):
+                reusefail("%.2f hours remaining, not enough" % (time_left / 60.0 / 60.0), outfile)
+            else:
                 if options.verbose:
-                    print "Checking if %s has at least %s hours left" % \
-                            (options.myproxyserver, minhours)
-                elif showprogress:
-                    sys.stdout.write('.')
-                    sys.stdout.flush()
-
-                myproxyusername = replace_certsubject(myproxyusername, existing)
-
-                sslsock = start_myproxy_command(outfile, '2', myproxyusername,
-                                'PASSPHRASE', 0)
-
-                response, params = parse_myproxy_response(sslsock)
-                if response:
-                    if options.debug:
-                        print "##### Begin MyProxy error text"
-                        print params['ERROR']
-                        print "##### End MyProxy error text"
-                    if options.verbose:
-                        print "No info retrieved from MyProxy, continuing"
-                elif 'CRED_END_TIME' not in params:
-                    fatal('no CRED_END_TIME in info retrieved from MyProxy')
+                    print "%.2f hours remaining, enough to reuse" % (time_left / 60.0 / 60.0)
+                canreuse = False
+                if options.myproxyserver is None:
+                    canreuse = True
                 else:
-                    endtime = int(params['CRED_END_TIME'])
-                    time_left = endtime - int(time.time())
-                    if time_left < 0:
-                        time_left = 0
+                    minhours = options.hours - options.proxyhours - options.minhours
+                    if options.verbose:
+                        print "Checking if %s has at least %s hours left" % \
+                                (options.myproxyserver, minhours)
+                    elif showprogress:
+                        sys.stdout.write('.')
+                        sys.stdout.flush()
 
-                    if time_left <= (minhours * 60 * 60):
-                        if options.verbose:
-                            print "%.2f hours remaining, not enough" % \
-                                (time_left / 60.0 / 60.0)
+                    myproxyusername = replace_certsubject(myproxyusername, existing)
+
+                    sslsock = start_myproxy_command(outfile, '2', myproxyusername,
+                                    'PASSPHRASE', 0)
+
+                    response, params = parse_myproxy_response(sslsock)
+                    if response:
+                        if options.debug:
+                            print "##### Begin MyProxy error text"
+                            print params['ERROR']
+                            print "##### End MyProxy error text"
+                        reusefail("no info retrieved from MyProxy", outfile)
+                    elif 'CRED_END_TIME' not in params:
+                        fatal('no CRED_END_TIME in info retrieved from MyProxy')
                     else:
-                        if options.verbose:
-                            print "%.2f hours remaining, enough to reuse" % \
-                                (time_left / 60.0 / 60.0)
-                        if options.myproxyretrievers is not None:
-                            if showprogress:
-                                sys.stdout.write('.')
-                                sys.stdout.flush()
-                            if ('CRED_RETRIEVER_TRUSTED' not in params) or \
-                                (params['CRED_RETRIEVER_TRUSTED'] != options.myproxyretrievers):
-                                if options.debug:
-                                    print "##### Begin MyProxy retrievers"
-                                    if 'CRED_RETRIEVER_TRUSTED' not in params:
-                                        print 'None'
-                                    else:
-                                        print params['CRED_RETRIEVER_TRUSTED']
-                                    print "##### End MyProxy retrievers"
-                                if options.verbose:
-                                    print "However the myproxyretrievers does not match"
-                            else:
-                                if options.debug:
-                                    print "myproxyretrievers also matches"
-                                canreuse = True
+                        endtime = int(params['CRED_END_TIME'])
+                        time_left = endtime - int(time.time())
+                        if time_left < 0:
+                            time_left = 0
+
+                        if time_left <= (minhours * 60 * 60):
+                            reusefail("%.2f hours remaining in MyProxy, not enough" % \
+                                    (time_left / 60.0 / 60.0), outfile)
                         else:
-                            canreuse = True
+                            if options.verbose:
+                                print "%.2f hours remaining, enough to reuse" % \
+                                    (time_left / 60.0 / 60.0)
+                            if options.myproxyretrievers is not None:
+                                if showprogress:
+                                    sys.stdout.write('.')
+                                    sys.stdout.flush()
+                                if ('CRED_RETRIEVER_TRUSTED' not in params) or \
+                                    (params['CRED_RETRIEVER_TRUSTED'] != options.myproxyretrievers):
+                                    if options.debug:
+                                        print "##### Begin MyProxy retrievers"
+                                        if 'CRED_RETRIEVER_TRUSTED' not in params:
+                                            print 'None'
+                                        else:
+                                            print params['CRED_RETRIEVER_TRUSTED']
+                                        print "##### End MyProxy retrievers"
+                                    reusefail("myproxyretrievers does not match in MyProxy", outfile)
+                                else:
+                                    if options.debug:
+                                        print "myproxyretrievers also matches"
+                                    canreuse = True
+                            else:
+                                canreuse = True
 
-            if canreuse:
-                if showprogress:
-                    print " yes"
-                sys.exit(0)
+                if canreuse:
+                    if showprogress:
+                        print " yes"
+                    sys.exit(0)
 
-        if showprogress:
-            print " no"
+            if showprogress:
+                print " no"
+    else:
+        showprogress = False
+        fatal(outfile + ' does not exist and --reuseonly is set')
+
+    if (options.reuseonly > 0):
+        fatal('Program error with reuseonly -- should not reach this point')
 
     ### Look up the IdP URL
     if options.verbose:

--- a/cigetcert.1
+++ b/cigetcert.1
@@ -161,6 +161,26 @@ certificate/key chain on the local machine.  The default is
 where %uid is the the current user id.
 .RE
 .TP
+.B \-\-reuseonly
+Only check to see if an existing certificate or proxy in the path
+of the
+.I \-\-out
+option can be reused (according to the algorithm shown in
+.I \-\-minhours
+below); do not get a new certificate if the old one cannot be reused.
+This defaults to true if a file at the
+.I \-\-out
+path already exists and is read-only, otherwise the default is false.
+.TP
+.B \-\-noreuseonly
+Negate the 
+.I \-\-reuseonly
+option; get a certificate if an old one cannot be reused.  If multiple 
+.I \-\-reuseonly
+and
+.I \-\-noreuseonly
+options are given, the last one specified applies.
+.TP
 .B \-\-minhours=num
 The minimum number of hours remaining before the existing local
 certificate chain expires in order to reuse it instead of making a
@@ -170,8 +190,6 @@ This feature is intended to reduce load on the servers.
 may be a floating point number to specify fractions of hours for this
 option (similarly for all other *hours options).
 The default is 12.
-In addition, the institution name has to match the 'O=' organization
-portion of the certificate subject Distinguished Name (DN).
 Also, if myproxy options (below) are set, in order to reuse a proxy it
 has to already exist in the myproxy server and have a minimum number
 of hours remaining according to this formula:

--- a/cigetcert.html
+++ b/cigetcert.html
@@ -1,5 +1,5 @@
 <!-- Creator     : groff version 1.18.1.1 -->
-<!-- CreationDate: Fri Jul  8 13:36:27 2016 -->
+<!-- CreationDate: Tue Jul 19 13:28:09 2016 -->
 <html>
 <head>
 <meta name="generator" content="groff -Thtml, see www.gnu.org">
@@ -500,6 +500,51 @@ The default is</p></td>
 <tr valign="top" align="left">
 <td width="10%"></td>
 <td width="89%">
+<p><b>&minus;&minus;reuseonly</b></p></td>
+</table>
+<!-- INDENTATION -->
+<table width="100%" border=0 rules="none" frame="void"
+       cols="2" cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="21%"></td>
+<td width="77%">
+<p>Only check to see if an existing certificate or proxy in
+the path of the <i>&minus;&minus;out</i> option can be
+reused (according to the algorithm shown in
+<i>&minus;&minus;minhours</i> below); do not get a new
+certificate if the old one cannot be reused. This defaults
+to true if a file at the <i>&minus;&minus;out</i> path
+already exists and is read-only, otherwise the default is
+false.</p>
+</td>
+</table>
+<!-- INDENTATION -->
+<table width="100%" border=0 rules="none" frame="void"
+       cols="2" cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="10%"></td>
+<td width="89%">
+<p><b>&minus;&minus;noreuseonly</b></p></td>
+</table>
+<!-- INDENTATION -->
+<table width="100%" border=0 rules="none" frame="void"
+       cols="2" cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="21%"></td>
+<td width="77%">
+<p>Negate the <i>&minus;&minus;reuseonly</i> option; get a
+certificate if an old one cannot be reused. If multiple
+<i>&minus;&minus;reuseonly</i> and
+<i>&minus;&minus;noreuseonly</i> options are given, the last
+one specified applies.</p>
+</td>
+</table>
+<!-- INDENTATION -->
+<table width="100%" border=0 rules="none" frame="void"
+       cols="2" cellspacing="0" cellpadding="0">
+<tr valign="top" align="left">
+<td width="10%"></td>
+<td width="89%">
 <p><b>&minus;&minus;minhours=num</b></p></td>
 </table>
 <!-- INDENTATION -->
@@ -513,13 +558,11 @@ local certificate chain expires in order to reuse it instead
 of making a new one. This feature is intended to reduce load
 on the servers. <i>num</i> may be a floating point number to
 specify fractions of hours for this option (similarly for
-all other *hours options). The default is 12. In addition,
-the institution name has to match the &rsquo;O=&rsquo;
-organization portion of the certificate subject
-Distinguished Name (DN). Also, if myproxy options (below)
-are set, in order to reuse a proxy it has to already exist
-in the myproxy server and have a minimum number of hours
-remaining according to this formula:</p></td>
+all other *hours options). The default is 12. Also, if
+myproxy options (below) are set, in order to reuse a proxy
+it has to already exist in the myproxy server and have a
+minimum number of hours remaining according to this
+formula:</p></td>
 </table>
 <!-- INDENTATION -->
 <table width="100%" border=0 rules="none" frame="void"

--- a/cigetcert.spec
+++ b/cigetcert.spec
@@ -53,8 +53,13 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Tue Jul 19 2016 Dave Dykstra <dwd@fnal.gov> 1.3-1
+- Add --reuseonly and --noreuseonly options.
+- When checking for reuse, do not require the institution name to
+  match the /O= in the DN.
 - Allow an institution to support only kerberos authentication: don't
   prompt for password if there's no non-kerberos IdP listed.
+- Remove extra newline at the end of fatal error messages.
 
 * Fri Jul 08 2016 Dave Dykstra <dwd@fnal.gov> 1.2-1
 - Try kerberos authentication first by default when the institution's


### PR DESCRIPTION
- Add --reuseonly and --noreuseonly options.
- When checking for reuse, do not require the institution name to match the /O= in the DN.
- Remove extra newline at the end of fatal error messages.
- Update to version 1.3
