### PR TITLE
Changes for version 1.4

### DIFF
--- a/README
+++ b/README
@@ -2,8 +2,8 @@
 
 
 Product Name:           cigetcert
-Product Version:        1.3
-Date (yyyy/mm/dd):      2016/07/19
+Product Version:        1.4
+Date (yyyy/mm/dd):      2016/07/20
 
 ------------------------------------------------------------------------
 

--- a/cigetcert
+++ b/cigetcert
@@ -26,7 +26,7 @@
 
 
 prog = "cigetcert"
-version = "1.3"
+version = "1.4"
 
 import sys
 import os

--- a/cigetcert
+++ b/cigetcert
@@ -661,7 +661,7 @@ def main():
 
             if showprogress:
                 print " no"
-    else:
+    elif options.reuseonly > 0:
         showprogress = False
         fatal(outfile + ' does not exist and --reuseonly is set')
 

--- a/cigetcert
+++ b/cigetcert
@@ -45,6 +45,7 @@ import base64
 import string
 import random
 import time
+import calendar
 from M2Crypto import SSL, X509, EVP, RSA, ASN1, m2
 from OpenSSL import crypto
 
@@ -190,12 +191,12 @@ class VerifiedHTTPSHandler(urllib2.HTTPSHandler):
         return response
 
 
-# Convert an ASN1_UTCTIME to local seconds since the epoch.
+# Convert an ASN1_UTCTIME to seconds since the epoch.
 # Would have used get_datetime() except it isn't supported before
 #   m2crypto 0.20 which is too new for RHEL5.
-def asn1time_local_secs(asn1time):
+def asn1time_epoch_secs(asn1time):
     timestruct = time.strptime(str(asn1time), '%b %d %H:%M:%S %Y GMT')
-    return int(time.mktime(timestruct) - time.timezone)
+    return int(calendar.timegm(timestruct))
 
 ### create a proxy certificate of a certificate ####
 # Based on code from the gridproxy library
@@ -223,7 +224,7 @@ def generate_proxycert(cert, certprivkey, lifehours, limited=False, bits=2048):
     not_after = ASN1.ASN1_UTCTIME()
     not_after_time = now + int(lifehours * 60 * 60)
     # make sure proxy doesn't expire later than the underlying cert
-    cert_not_after_time = asn1time_local_secs(cert.get_not_after())
+    cert_not_after_time = asn1time_epoch_secs(cert.get_not_after())
     if not_after_time > cert_not_after_time:
         not_after_time = cert_not_after_time
     not_after.set_time(not_after_time)
@@ -586,7 +587,7 @@ def main():
                 # this happens on el5 when the old outfile is empty
                 time_left = 0
             else:
-                time_left = asn1time_local_secs(existing.get_not_after()) - time.time()
+                time_left = asn1time_epoch_secs(existing.get_not_after()) - time.time()
                 if time_left < 0:
                     time_left = 0
             if time_left <= (options.minhours * 60 * 60):
@@ -1096,7 +1097,7 @@ def main():
         print "issuer   : " + x509name_to_str(firstcert.get_issuer())
 
     if options.verbose or showprogress:
-        validuntil = time.ctime(asn1time_local_secs(firstcert.get_not_after()))
+        validuntil = time.ctime(asn1time_epoch_secs(firstcert.get_not_after()))
         print 'Your ' + proxyorcert + ' is valid until: ' + validuntil
 
     ### MyProxy handling section

--- a/cigetcert.spec
+++ b/cigetcert.spec
@@ -1,6 +1,6 @@
 Summary: Get an X.509 certificate with SAML ECP and store proxies
 Name: cigetcert
-Version: 1.2
+Version: 1.4
 Release: 1%{?dist}
 License: BSD
 Group: Applications/System
@@ -53,6 +53,11 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 20 2016 Dave Dykstra <dwd@fnal.gov> 1.4-1
+- Use more reliable method of calculating seconds since the epoch.  It
+  was off by an hour.
+- Fix broken case of proxy not previously existing without --reuseonly.
+
 * Tue Jul 19 2016 Dave Dykstra <dwd@fnal.gov> 1.3-1
 - Add --reuseonly and --noreuseonly options.
 - When checking for reuse, do not require the institution name to


### PR DESCRIPTION
- Use more reliable method of calculating seconds since the epoch.  It was off by an hour.
- Fix broken case of proxy not previously existing without --reuseonly.