### PR TITLE
Update default CA files/paths

### DIFF
--- a/cigetcert
+++ b/cigetcert
@@ -67,7 +67,7 @@ from optparse import OptionParser
 
 # get the default certificates paths for this platform
 _default_cafile = '/etc/ssl/certs/ca-certificates.crt'  # debian
-_default_capath = os.getenv('X509_CERT_DIR') or "/etc/grid-security/certificates"
+_default_capath = "/etc/grid-security/certificates"
 try:
     _paths = ssl.get_default_verify_paths()
 except AttributeError:  # python < 2.7
@@ -84,7 +84,7 @@ defaults = {
     "spurl": "https://ecp.cilogon.org/secure/getcert",
     "idplisturl": "https://cilogon.org/include/ecpidps.txt",
     "cafile": _default_cafile if os.path.isfile(_default_cafile or '') else None,
-    "capath": _default_capath if os.path.isdir(_default_capath or '') else None,
+    "capath": _default_capath,
 }
 
 # these are global
@@ -447,6 +447,11 @@ def parseargs(parser, argv):
     if len(args) != 0:
         usage(parser, "no non-option arguments expected")
 
+    # This is done here because capath may be needed to retrieve
+    #  the options file.
+    if options.capath is None:
+        options.capath = os.getenv('X509_CERT_DIR') or defaults['capath']
+
 
 ###  cigetcert main ####
 def main():
@@ -482,8 +487,10 @@ def main():
                       metavar="file", default=defaults['cafile'],
                       help="Certifying Authority certificates bundle file")
     parser.add_option("", "--capath",
-                      metavar="path", default=defaults['capath'],
-                      help="Certifying Authority certificates directory")
+                      metavar="path",
+                      help="Certifying Authority certificates directory " +
+                      '[default: $X509_CERT_DIR or ' +
+                      defaults['capath'] + ']')
     parser.add_option("-k", "--kerberos",
                       action="store_const", const=1, default=0,
                       help="prefer kerberos authentication if available")

--- a/cigetcert
+++ b/cigetcert
@@ -65,15 +65,26 @@ from OpenSSL import crypto
 import shlex
 from optparse import OptionParser
 
-DEFAULT_VERIFY_PATHS = ssl.get_default_verify_paths()
-DEFAULT_CAFILE = '/etc/ssl/certs/ca-certificates.crt'  # debian
+# get the default certificates paths for this platform
+_default_cafile = '/etc/ssl/certs/ca-certificates.crt'  # debian
+_default_capath = os.getenv('X509_CERT_DIR') or "/etc/grid-security/certificates"
+try:
+    _paths = ssl.get_default_verify_paths()
+except AttributeError:  # python < 2.7
+    pass
+else:
+    # always prefer python's default cafile
+    if _paths.cafile:
+        _default_cafile = _paths.cafile
+    # prefer grid-security default capath
+    if _paths.capath and not os.path.isdir(_default_capath):
+        _default_capath = _paths.capath
+
 defaults = {
     "spurl": "https://ecp.cilogon.org/secure/getcert",
     "idplisturl": "https://cilogon.org/include/ecpidps.txt",
-    "cafile": DEFAULT_VERIFY_PATHS.cafile or DEFAULT_CA_FILE,
-    "capath": os.getenv('X509_CERT_DIR') or
-              DEFAULT_VERIFY_PATHS.capath or
-              "/etc/grid-security/certificates",
+    "cafile": _default_cafile if os.path.isfile(_default_cafile or '') else None,
+    "capath": _default_capath if os.path.isdir(_default_capath or '') else None,
 }
 
 # these are global
@@ -436,14 +447,6 @@ def parseargs(parser, argv):
     if len(args) != 0:
         usage(parser, "no non-option arguments expected")
 
-    # This is done here because capath may be needed to retrieve
-    #  the options file.
-    if options.capath is None:
-        capath = os.getenv('X509_CERT_DIR')
-        if capath is None:
-            capath = defaults['capath']
-        options.capath = str(capath)
-
 
 ###  cigetcert main ####
 def main():
@@ -479,10 +482,8 @@ def main():
                       metavar="file", default=defaults['cafile'],
                       help="Certifying Authority certificates bundle file")
     parser.add_option("", "--capath",
-                      metavar="path",
-                      help="Certifying Authority certificates directory " +
-                      '[default: $X509_CERT_DIR or ' +
-                      defaults['capath'] + ']')
+                      metavar="path", default=defaults['capath'],
+                      help="Certifying Authority certificates directory")
     parser.add_option("-k", "--kerberos",
                       action="store_const", const=1, default=0,
                       help="prefer kerberos authentication if available")

--- a/cigetcert
+++ b/cigetcert
@@ -79,11 +79,13 @@ else:
     # prefer grid-security default capath
     if _paths.capath and not os.path.isdir(_default_capath):
         _default_capath = _paths.capath
+if not os.path.isfile(_default_cafile or ''):  # use ca-certificates file:
+    _default_cafile = "/etc/pki/tls/cert.pem"
 
 defaults = {
     "spurl": "https://ecp.cilogon.org/secure/getcert",
     "idplisturl": "https://cilogon.org/include/ecpidps.txt",
-    "cafile": _default_cafile if os.path.isfile(_default_cafile or '') else None,
+    "cafile": _default_cafile,
     "capath": _default_capath,
 }
 

--- a/cigetcert
+++ b/cigetcert
@@ -41,6 +41,7 @@ import random
 import math
 import time
 import calendar
+import ssl
 import struct
 import tempfile
 
@@ -64,15 +65,16 @@ from OpenSSL import crypto
 import shlex
 from optparse import OptionParser
 
+DEFAULT_VERIFY_PATHS = ssl.get_default_verify_paths()
+DEFAULT_CAFILE = '/etc/ssl/certs/ca-certificates.crt'  # debian
 defaults = {
     "spurl": "https://ecp.cilogon.org/secure/getcert",
     "idplisturl": "https://cilogon.org/include/ecpidps.txt",
-    "cafile": "/etc/pki/tls/cert.pem",
-    "capath": "/etc/grid-security/certificates"
+    "cafile": DEFAULT_VERIFY_PATHS.cafile or DEFAULT_CA_FILE,
+    "capath": os.getenv('X509_CERT_DIR') or
+              DEFAULT_VERIFY_PATHS.capath or
+              "/etc/grid-security/certificates",
 }
-
-# this is the default CA file on Debian
-altcafile = '/etc/ssl/certs/ca-certificates.crt'
 
 # these are global
 options = None
@@ -473,8 +475,6 @@ def main():
     parser.add_option("", "--spurl",
                       metavar="URL", default=defaults['spurl'],
                       help="Service Provider URL")
-    if not os.path.isfile(defaults['cafile']) and os.path.isfile(altcafile):
-        defaults['cafile'] = altcafile
     parser.add_option("", "--cafile",
                       metavar="file", default=defaults['cafile'],
                       help="Certifying Authority certificates bundle file")


### PR DESCRIPTION
This PR updates the default `CA` files and paths on `cigetcert` to support more platforms out-of-the-box. This should be backwards-compatible with the current version.