### PR TITLE
Add a build target for fedora-copr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 *.egg-info/
 dist/
 cigetcert-*.tar.gz
+cigetcert-*.src.rpm

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ cigetcert.html: cigetcert.1
 # For koji builds
 sources:
 	@tar cf - *  --transform="s,^,cigetcert-$(VERSION)/," | gzip --best > cigetcert-$(VERSION).tar.gz
+
+# For copr builds
+srpm: sources
+	rpmbuild -bs --define '_sourcedir .' --define '_srcrpmdir .' cigetcert.spec

--- a/cigetcert.spec
+++ b/cigetcert.spec
@@ -61,6 +61,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %changelog
 #- Add make sources target for koji build
+#- Add make srpm target for copr build
 #- Support port numbers in https urls
 
 * Wed Feb 26 2020 Dave Dykstra <dwd@fnal.gov> 1.19-2


### PR DESCRIPTION
As I'm planning out build support for EL9, having native Fedora Copr support is a bit handy.